### PR TITLE
PDF -> images conversion script

### DIFF
--- a/tools/butterfly-images.md
+++ b/tools/butterfly-images.md
@@ -1,0 +1,33 @@
+# Butterfly Images
+
+## Prerequisites
+The dependencies of the `extract.sh` script are listed in the file itself.
+
+## General Process
+1. Run `./extract.sh butterflies.pdf`.
+2. Fix the anomalies manually (see below).
+3. Run `./rename.sh images butterflies`.
+
+All of the extracted images will be contained in folder `butterflies`, with
+names of the form `butterfly-#-#.png`, where the first number is the number of
+the page the image was extracted from, and the second number refers to the
+image within the page.
+
+## Anomalies
+
+The PDF processing script isn't perfect, as the PDF isn't completely uniform.
+Different pages have slightly different formats, so the output is slightly
+different for every page. The below pages have anomalies that must be corrected
+manually.
+
+- page 16: split-003 is something random
+- page 25: split-002 is rotated randomly
+- page 33: split-004 is something random
+- page 39: split-002 is something random
+- page 44: 0-Im2 also needs to be split
+- page 52: empty
+- page 56: empty
+- page 70: split-001 is something random
+- page 89: 0-Im3 also needs to be split
+- page 89: split-001 - split-003.png are something random
+- page 91: wacky as hell

--- a/tools/extract.sh
+++ b/tools/extract.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -e
+
+# Necessary prerequisites:
+# pdftk (on Debian/Ubuntu: sudo apt install pdftk)
+# libopenjp2-tools (on Debian/Ubuntu: sudo apt install libopenjp2-tools)
+# pdfly (pip install pdfly)
+# imagemagick (mine is 7.1.1, built from source)
+# multicrop imagemagick script in the same directory (http://www.fmwconcepts.com/imagemagick/multicrop/index.php)
+
+usage() {
+    printf 'Usage: %s [-h|--help] <INPUT>\n' $0
+    printf '\055h|--help\t\t\tShow this help message\n'
+    printf 'INPUT\t\t\t\tThe input PDF file\n'
+}
+
+if [[ $# -ne 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+    usage
+    exit 1
+fi
+
+input="$1"
+root=$(pwd)
+
+printf 'Splitting "%s" into pages...' "$input"
+mkdir pages
+pdftk "$input" burst output pages/%02d.pdf
+printf '\rSplitting "%s" into pages...Done.\n' "$input"
+
+mkdir images
+i=1
+for pagePath in pages/*.pdf; do
+    pageName=$(printf "$pagePath" | sed 's?^\(.*/\)*\(.*\)\.pdf$?\2?')
+    imageDir="$root/images/$pageName"
+
+    mkdir "$imageDir"
+    cd "$imageDir"
+
+    printf 'Extracting images from page %d:\n' $i
+    /usr/bin/env python -m pdfly extract-images "$root/$pagePath"
+
+    mapfile -t images < <(ls -l *.jp2 | awk '{if ($5 >= 100000) print $9}')
+    for image in "${images[@]}"; do
+        imageOutput=$(printf "$image" | sed 's/\.jp2/.png/')
+        printf 'Converting %s to %s:\n' "$image" "$imageOutput"
+        opj_decompress -i "$image" -o "$imageOutput"
+    done
+    
+    rm *.jp2
+    mapfile -t remove < <(ls -l | awk 'NR > 1{if ($5 < 100000) print $9}')
+    if [[ ${#remove[@]} -gt 0 ]]; then
+        rm "${remove[@]}"
+    fi
+
+    if [[ -e "0-Im1.png" ]]; then
+        printf 'Splitting images (page %d)\n' $i
+        "$root/multicrop" 0-Im1.png split.png
+        rm 0-Im1.png
+    else
+        printf 'Images are already split (page %d)\n' $i
+        rm 0-Im0.png
+    fi
+
+    ((i++))
+done

--- a/tools/extract.sh
+++ b/tools/extract.sh
@@ -14,24 +14,28 @@ usage() {
     printf 'INPUT\t\t\t\tThe input PDF file\n'
 }
 
+# Check for help flags or incorrect number of arguments
 if [[ $# -ne 1 || "$1" == "-h" || "$1" == "--help" ]]; then
     usage
     exit 1
 fi
 
-input="$1"
-root=$(pwd)
+input="$1" # input is the first command-line argument
+root=$(pwd) # root is the current directory
 
 printf 'Splitting "%s" into pages...' "$input"
 mkdir pages
+# Splits the input PDF into many PDFs, each that is one page.
 pdftk "$input" burst output pages/%02d.pdf
 printf '\rSplitting "%s" into pages...Done.\n' "$input"
 
 mkdir images
-i=1
+i=1 # page number
 for pagePath in pages/*.pdf; do
+    # name of page -- strips pdf extension and path
+    # should be a two digit number
     pageName=$(printf "$pagePath" | sed 's?^\(.*/\)*\(.*\)\.pdf$?\2?')
-    imageDir="$root/images/$pageName"
+    imageDir="$root/images/$pageName" # directory to output images for this page
 
     mkdir "$imageDir"
     cd "$imageDir"
@@ -39,25 +43,39 @@ for pagePath in pages/*.pdf; do
     printf 'Extracting images from page %d:\n' $i
     /usr/bin/env python -m pdfly extract-images "$root/$pagePath"
 
+    # Set the array "images" to contain the jp2 files that are at least 100K in size
+    # These are the images we'll convert to png
     mapfile -t images < <(ls -l *.jp2 | awk '{if ($5 >= 100000) print $9}')
     for image in "${images[@]}"; do
+        # Replace .jp2 extension with .png
         imageOutput=$(printf "$image" | sed 's/\.jp2/.png/')
         printf 'Converting %s to %s:\n' "$image" "$imageOutput"
+        # Convert jp2 file to a png
         opj_decompress -i "$image" -o "$imageOutput"
     done
     
     rm *.jp2
+    # Set the array "remove" to contain all files that are less than 100K in size
     mapfile -t remove < <(ls -l | awk 'NR > 1{if ($5 < 100000) print $9}')
+    # Delete every file in "remove" if it's not empty.
     if [[ ${#remove[@]} -gt 0 ]]; then
         rm "${remove[@]}"
     fi
 
+    # If this file exists, it's likely a composite image consisting of multiple
+    # butterfly images. We'll split it by whitespace into the component images.
+    # Note that this heuristic is only an approximation, as some pages
+    # are layed out slightly differently.
     if [[ -e "0-Im1.png" ]]; then
         printf 'Splitting images (page %d)\n' $i
+        # Use multicrop script to split by whitespace.
         "$root/multicrop" 0-Im1.png split.png
+        # Remove the composite image
         rm 0-Im1.png
     else
+        # Images were included separately in the PDF.
         printf 'Images are already split (page %d)\n' $i
+        # Likely an image containing text and such
         rm 0-Im0.png
     fi
 

--- a/tools/rename.sh
+++ b/tools/rename.sh
@@ -8,23 +8,32 @@ usage() {
     printf 'OUTDIR\t\t\t\tThe output folder\n'
 }
 
+# Check for help flags and incorrect number of arguments
 if [[ $# -ne 2 || "$1" == "-h" || "$1" == "--help" ]]; then
     usage
     exit 1
 fi
 
-indir="$1"
-outdir="$2"
+indir="$1" # first argument is input directory
+outdir="$2" # second argument is output directory
 
 mkdir "$outdir"
 
+# Set the array "dirs" to contain the child directories of $indir.
 mapfile -t dirs < <(ls -ld "$indir"/*/ | awk '{print $9}')
 for dir in "${dirs[@]}"; do
     printf 'Traversing %s:\n' "$dir"
+    # Set the array "files" to contain the child files in $dir.
     mapfile -t files < <(ls -l "$dir"* | awk '{print $9}')
+    # Take last path component.
+    # For example, this transforms input/01/ to 01
     dirName=$(printf "$dir" | sed 's~^\([^/]*/\)*\([^/]\+\)/\?$~\2~')
     i=1
     for file in "${files[@]}"; do
+        # Need to construct the sed command separately to include variable values in it
+        # The sed command replaces the entire file path with the intended filename,
+        # in the form butterfly-01-1.png.
+        # Note that the extension of the input is maintained for the output.
         sedLine=$(printf 's?^.\+\.\([^.]\+\)$?butterfly-%s-%d.\\1?' "$dirName" $i)
         outFilename=$(printf "$file" | sed $sedLine)
         outFile="$outdir/$outFilename"

--- a/tools/rename.sh
+++ b/tools/rename.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+usage() {
+    printf 'Usage: %s [-h|--help] <INDIR> <OUTDIR>\n' $0
+    printf '\055h|--help\t\t\tShow this help message\n'
+    printf 'INDIR\t\t\t\tThe input folder\n'
+    printf 'OUTDIR\t\t\t\tThe output folder\n'
+}
+
+if [[ $# -ne 2 || "$1" == "-h" || "$1" == "--help" ]]; then
+    usage
+    exit 1
+fi
+
+indir="$1"
+outdir="$2"
+
+mkdir "$outdir"
+
+mapfile -t dirs < <(ls -ld "$indir"/*/ | awk '{print $9}')
+for dir in "${dirs[@]}"; do
+    printf 'Traversing %s:\n' "$dir"
+    mapfile -t files < <(ls -l "$dir"* | awk '{print $9}')
+    dirName=$(printf "$dir" | sed 's~^\([^/]*/\)*\([^/]\+\)/\?$~\2~')
+    i=1
+    for file in "${files[@]}"; do
+        sedLine=$(printf 's?^.\+\.\([^.]\+\)$?butterfly-%s-%d.\\1?' "$dirName" $i)
+        outFilename=$(printf "$file" | sed $sedLine)
+        outFile="$outdir/$outFilename"
+        printf '\tFile: %s -> %s\n' "$file" "$outFile"
+        cp "$file" "$outFile"
+        ((i++))
+    done
+done


### PR DESCRIPTION
This PR includes scripts for converting the provided butterfly identification PDF into images.

The general idea is this:
- split the PDF into one PDF per page
- extract the images from each page (these are output in the form of .jp2 images)
- convert the larger .jp2 images (>= 100K) into png images
- remove all jp2 and small png images
- if necessary, split composite pngs (those consisting of several butterfly images) into the component images

Unfortunately, the script isn't fully generalizable and employs heuristics likely specific to this PDF document. In addition, after running the extract script, there are several manual tweaks necessary (detailed in butterfly-images.md). After making the manual tweaks, run the rename script to copy the images into an output directory and rename them to something sensible.