### PR TITLE
Restyle tab bar

### DIFF
--- a/hmns-app/client/app/(tabs)/_layout.tsx
+++ b/hmns-app/client/app/(tabs)/_layout.tsx
@@ -42,7 +42,17 @@ export default function TabLayout () {
 			screenOptions={{
 				tabBarActiveTintColor: tabBarIconColor,
 				tabBarInactiveTintColor: tabBarIconColor,
-				tabBarStyle: {backgroundColor: "white",},
+				tabBarStyle: {
+                    backgroundColor: "white",
+                    height: 80,
+                },
+                tabBarItemStyle: {
+                    marginTop: 10,
+                },
+                tabBarLabelStyle: {
+                    fontSize: 12,
+                    marginBottom: 10,
+                },
 				headerShown: false
 			}}>
 			<Tabs.Screen

--- a/hmns-app/client/app/(tabs)/_layout.tsx
+++ b/hmns-app/client/app/(tabs)/_layout.tsx
@@ -9,12 +9,14 @@ const tabBarIconSelectedColor = '#E6E5D4';
 const tabBarIconStyles = StyleSheet.create({
     focused: {
         backgroundColor: tabBarIconSelectedColor,
+        borderRadius: tabBarIconSelectedSize / 2,
+    },
+    default: {
         width: tabBarIconSelectedSize,
         height: tabBarIconSelectedSize,
-        borderRadius: tabBarIconSelectedSize / 2,
         alignItems: 'center',
         justifyContent: 'center',
-    },
+    }
 });
 
 /**
@@ -26,7 +28,7 @@ function TabBarIcon (props: {
   focused: boolean,
 }) {
 	return (
-		<View style={(props.focused ? tabBarIconStyles.focused : {})}>
+		<View style={[tabBarIconStyles.default, (props.focused && tabBarIconStyles.focused)]}>
 			<Feather size={tabBarIconSize} {...props} />
 		</View>
 	);

--- a/hmns-app/client/app/(tabs)/_layout.tsx
+++ b/hmns-app/client/app/(tabs)/_layout.tsx
@@ -46,7 +46,7 @@ export default function TabLayout() {
                 tabBarInactiveTintColor: tabBarIconColor,
                 tabBarStyle: {
                     backgroundColor: "white",
-                    height: 80 + insets.bottom,
+                    height: 75 + insets.bottom,
                     borderTopWidth: 0,
                 },
                 tabBarItemStyle: {

--- a/hmns-app/client/app/(tabs)/_layout.tsx
+++ b/hmns-app/client/app/(tabs)/_layout.tsx
@@ -45,6 +45,7 @@ export default function TabLayout() {
                 tabBarStyle: {
                     backgroundColor: "white",
                     height: 80,
+                    borderTopWidth: 0,
                 },
                 tabBarItemStyle: {
                     marginTop: 10,

--- a/hmns-app/client/app/(tabs)/_layout.tsx
+++ b/hmns-app/client/app/(tabs)/_layout.tsx
@@ -2,8 +2,8 @@ import { Feather } from '@expo/vector-icons';
 import { Tabs } from "expo-router";
 import { StyleSheet, View, useColorScheme } from "react-native";
 
-const tabBarIconSize = 28;
-const tabBarIconSelectedSize = tabBarIconSize + 15;
+const tabBarIconSize = 26;
+const tabBarIconSelectedSize = tabBarIconSize + 17;
 const tabBarIconColor = '#5F5541';
 const tabBarIconSelectedColor = '#E6E5D4';
 const tabBarIconStyles = StyleSheet.create({

--- a/hmns-app/client/app/(tabs)/_layout.tsx
+++ b/hmns-app/client/app/(tabs)/_layout.tsx
@@ -1,6 +1,7 @@
 import { Feather } from '@expo/vector-icons';
 import { Tabs } from "expo-router";
 import { StyleSheet, View, useColorScheme } from "react-native";
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const tabBarIconSize = 26;
 const tabBarIconSelectedSize = tabBarIconSize + 17;
@@ -36,6 +37,7 @@ function TabBarIcon(props: {
 
 export default function TabLayout() {
     const colorScheme = useColorScheme();
+    const insets = useSafeAreaInsets();
 
     return (
         <Tabs
@@ -44,7 +46,7 @@ export default function TabLayout() {
                 tabBarInactiveTintColor: tabBarIconColor,
                 tabBarStyle: {
                     backgroundColor: "white",
-                    height: 80,
+                    height: 80 + insets.bottom,
                     borderTopWidth: 0,
                 },
                 tabBarItemStyle: {

--- a/hmns-app/client/app/(tabs)/_layout.tsx
+++ b/hmns-app/client/app/(tabs)/_layout.tsx
@@ -1,19 +1,27 @@
-import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { Feather, FontAwesome } from '@expo/vector-icons';
 import { Link, Tabs } from "expo-router";
-import { Pressable, View, useColorScheme } from "react-native";
+import { Pressable, StyleSheet, View, useColorScheme } from "react-native";
 
 import Colors from "../../constants/Colors";
+
+const tabBarIconColor = '#5F5541';
+const tabBarIconStyles = StyleSheet.create({
+    focused: {
+        backgroundColor: 'red',
+    },
+});
 
 /**
  * You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
  */
 function TabBarIcon (props: {
-  name: React.ComponentProps<typeof FontAwesome>["name"]
-  color: string
+  name: React.ComponentProps<typeof Feather>["name"]
+  color: string,
+  focused: boolean,
 }) {
 	return (
-		<View style={{}}>
-			<FontAwesome size={28} style={{ marginBottom: -16 }} {...props} />
+		<View style={(props.focused ? tabBarIconStyles.focused : {})}>
+			<Feather size={28} style={{ marginBottom: -16 }} {...props} />
 		</View>
 	);
 }
@@ -24,7 +32,8 @@ export default function TabLayout () {
 	return (
 		<Tabs
 			screenOptions={{
-				tabBarActiveTintColor:"grey",
+				tabBarActiveTintColor: tabBarIconColor,
+				tabBarInactiveTintColor: tabBarIconColor,
 				tabBarStyle: {backgroundColor: "white",},
 				headerShown: false
 			}}>
@@ -32,8 +41,8 @@ export default function TabLayout () {
 				name='index'
 				options={{
 					title: "Home",
-					tabBarIcon: ({ color }) => (
-						<TabBarIcon name='home' color={color} />
+					tabBarIcon: ({ color, focused }) => (
+						<TabBarIcon name='home' color={color} focused={focused} />
 					),
 					headerRight: () => (
 						<Link href='/modal' asChild>
@@ -55,8 +64,8 @@ export default function TabLayout () {
 				name='glossary'
 				options={{
 					title: "Glossary",
-					tabBarIcon: ({ color }) => (
-						<TabBarIcon name='list' color={color} />
+					tabBarIcon: ({ color, focused }) => (
+						<TabBarIcon name='list' color={color} focused={focused} />
 					)
 				}}
 			/>
@@ -64,8 +73,8 @@ export default function TabLayout () {
 				name='two'
 				options={{
 					title: "Camera",
-					tabBarIcon: ({ color }) => (
-						<TabBarIcon name='camera' color={color} />
+					tabBarIcon: ({ color, focused }) => (
+						<TabBarIcon name='camera' color={color} focused={focused} />
 					)
 				}}
 			/>
@@ -73,8 +82,8 @@ export default function TabLayout () {
 				name='info'
 				options={{
 					title: "Info",
-					tabBarIcon: ({ color }) => (
-						<TabBarIcon name='info' color={color} />
+					tabBarIcon: ({ color, focused }) => (
+						<TabBarIcon name='info' color={color} focused={focused} />
 					)
 				}}
 			/>

--- a/hmns-app/client/app/(tabs)/_layout.tsx
+++ b/hmns-app/client/app/(tabs)/_layout.tsx
@@ -4,10 +4,18 @@ import { Pressable, StyleSheet, View, useColorScheme } from "react-native";
 
 import Colors from "../../constants/Colors";
 
+const tabBarIconSize = 28;
+const tabBarIconSelectedSize = tabBarIconSize + 15;
 const tabBarIconColor = '#5F5541';
+const tabBarIconSelectedColor = '#E6E5D4';
 const tabBarIconStyles = StyleSheet.create({
     focused: {
-        backgroundColor: 'red',
+        backgroundColor: tabBarIconSelectedColor,
+        width: tabBarIconSelectedSize,
+        height: tabBarIconSelectedSize,
+        borderRadius: tabBarIconSelectedSize / 2,
+        alignItems: 'center',
+        justifyContent: 'center',
     },
 });
 
@@ -21,7 +29,7 @@ function TabBarIcon (props: {
 }) {
 	return (
 		<View style={(props.focused ? tabBarIconStyles.focused : {})}>
-			<Feather size={28} style={{ marginBottom: -16 }} {...props} />
+			<Feather size={tabBarIconSize} {...props} />
 		</View>
 	);
 }

--- a/hmns-app/client/app/(tabs)/_layout.tsx
+++ b/hmns-app/client/app/(tabs)/_layout.tsx
@@ -22,27 +22,27 @@ const tabBarIconStyles = StyleSheet.create({
 /**
  * You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
  */
-function TabBarIcon (props: {
-  name: React.ComponentProps<typeof Feather>["name"]
-  color: string,
-  focused: boolean,
+function TabBarIcon(props: {
+    name: React.ComponentProps<typeof Feather>["name"]
+    color: string,
+    focused: boolean,
 }) {
-	return (
-		<View style={[tabBarIconStyles.default, (props.focused && tabBarIconStyles.focused)]}>
-			<Feather size={tabBarIconSize} {...props} />
-		</View>
-	);
+    return (
+        <View style={[tabBarIconStyles.default, (props.focused && tabBarIconStyles.focused)]}>
+            <Feather size={tabBarIconSize} {...props} />
+        </View>
+    );
 }
 
-export default function TabLayout () {
-	const colorScheme = useColorScheme();
+export default function TabLayout() {
+    const colorScheme = useColorScheme();
 
-	return (
-		<Tabs
-			screenOptions={{
-				tabBarActiveTintColor: tabBarIconColor,
-				tabBarInactiveTintColor: tabBarIconColor,
-				tabBarStyle: {
+    return (
+        <Tabs
+            screenOptions={{
+                tabBarActiveTintColor: tabBarIconColor,
+                tabBarInactiveTintColor: tabBarIconColor,
+                tabBarStyle: {
                     backgroundColor: "white",
                     height: 80,
                 },
@@ -53,44 +53,44 @@ export default function TabLayout () {
                     fontSize: 12,
                     marginBottom: 10,
                 },
-				headerShown: false
-			}}>
-			<Tabs.Screen
-				name='index'
-				options={{
-					title: "Home",
-					tabBarIcon: ({ color, focused }) => (
-						<TabBarIcon name='home' color={color} focused={focused} />
-					)
-				}}
-			/>
-			<Tabs.Screen
-				name='glossary'
-				options={{
-					title: "Glossary",
-					tabBarIcon: ({ color, focused }) => (
-						<TabBarIcon name='list' color={color} focused={focused} />
-					)
-				}}
-			/>
-			<Tabs.Screen
-				name='two'
-				options={{
-					title: "Camera",
-					tabBarIcon: ({ color, focused }) => (
-						<TabBarIcon name='camera' color={color} focused={focused} />
-					)
-				}}
-			/>
-			<Tabs.Screen
-				name='info'
-				options={{
-					title: "Info",
-					tabBarIcon: ({ color, focused }) => (
-						<TabBarIcon name='info' color={color} focused={focused} />
-					)
-				}}
-			/>
-		</Tabs>
-	);
+                headerShown: false
+            }}>
+            <Tabs.Screen
+                name='index'
+                options={{
+                    title: "Home",
+                    tabBarIcon: ({ color, focused }) => (
+                        <TabBarIcon name='home' color={color} focused={focused} />
+                    )
+                }}
+            />
+            <Tabs.Screen
+                name='glossary'
+                options={{
+                    title: "Glossary",
+                    tabBarIcon: ({ color, focused }) => (
+                        <TabBarIcon name='list' color={color} focused={focused} />
+                    )
+                }}
+            />
+            <Tabs.Screen
+                name='two'
+                options={{
+                    title: "Camera",
+                    tabBarIcon: ({ color, focused }) => (
+                        <TabBarIcon name='camera' color={color} focused={focused} />
+                    )
+                }}
+            />
+            <Tabs.Screen
+                name='info'
+                options={{
+                    title: "Info",
+                    tabBarIcon: ({ color, focused }) => (
+                        <TabBarIcon name='info' color={color} focused={focused} />
+                    )
+                }}
+            />
+        </Tabs>
+    );
 }

--- a/hmns-app/client/app/(tabs)/_layout.tsx
+++ b/hmns-app/client/app/(tabs)/_layout.tsx
@@ -1,8 +1,6 @@
-import { Feather, FontAwesome } from '@expo/vector-icons';
-import { Link, Tabs } from "expo-router";
-import { Pressable, StyleSheet, View, useColorScheme } from "react-native";
-
-import Colors from "../../constants/Colors";
+import { Feather } from '@expo/vector-icons';
+import { Tabs } from "expo-router";
+import { StyleSheet, View, useColorScheme } from "react-native";
 
 const tabBarIconSize = 28;
 const tabBarIconSelectedSize = tabBarIconSize + 15;
@@ -51,21 +49,7 @@ export default function TabLayout () {
 					title: "Home",
 					tabBarIcon: ({ color, focused }) => (
 						<TabBarIcon name='home' color={color} focused={focused} />
-					),
-					headerRight: () => (
-						<Link href='/modal' asChild>
-							<Pressable>
-								{({ pressed }) => (
-									<FontAwesome
-										name='info-circle'
-										size={25}
-										color={Colors[colorScheme ?? "light"].text}
-										style={{ marginRight: 15, opacity: pressed ? 0.5 : 1 }}
-									/>
-								)}
-							</Pressable>
-						</Link>
-					),
+					)
 				}}
 			/>
 			<Tabs.Screen


### PR DESCRIPTION
This PR restyles the tab bar (bar at bottom of app that selects which screen you're on) to match the new design.

The new design can be found on the Figma: go to the Wireframes page, "Component 6" in the top right of the "Actual Final" set. I've included an image below.
![tab_bar](https://github.com/rice-apps/hmns/assets/53383381/9517b8b6-0440-43e9-9b2a-e8131172caa5)
